### PR TITLE
stop breadcrumbs getting in the way of the search on a small window

### DIFF
--- a/web/static/css/dfeed.css
+++ b/web/static/css/dfeed.css
@@ -1,4 +1,3 @@
-
 /*************** Font size / side menu ***************/
 
 /* narrow pages (most views) */
@@ -53,6 +52,7 @@
 	font-size: 1.7em;
 	font-family: Georgia, "Times New Roman", Times, serif;
 	font-variant: small-caps;
+	z-index: -1;
 }
 
 #breadcrumbs a {


### PR DESCRIPTION
It's white-on-white anyway, so it might as well be behind the search and not get in the way.

Original complaint: http://forum.dlang.org/post/ustasylbonrjjuitjmtv@forum.dlang.org
