### PR TITLE
web: Add pagination at the top as well as bottom

### DIFF
--- a/web.d
+++ b/web.d
@@ -1455,10 +1455,7 @@ class WebUI
 		if (nested)
 			posts = Rfc850Post.threadify(posts);
 
-		foreach (post; posts)
-			formatPost(post, knownPosts);
-
-		if (!nested)
+		void printPagination()
 		{
 			auto postCount = getPostCount(id);
 
@@ -1469,6 +1466,17 @@ class WebUI
 				html.put(`</table>`);
 			}
 		}
+
+		// Print the pagination at the top
+		if (!nested)
+			printPagination();
+
+		foreach (post; posts)
+			formatPost(post, knownPosts);
+
+		// ...and at the bottom
+		if (!nested)
+			printPagination();
 	}
 
 	void discussionThreadOverview(string threadID, string selectedID)


### PR DESCRIPTION
THIS IS UNTESTED because I wasn't able to build, due to various errors; it should be simple enough to Just Work™, though.

This is for issue #16.

It basically does what it says on the lid: adds the pagination above the posts as well as below.


Contributions are licensed under AGPLv3 (or later).