### PR TITLE
Rewrapping for non-RFC input text

### DIFF
--- a/wrap.d
+++ b/wrap.d
@@ -192,4 +192,9 @@ unittest
 	static assert(str.toUTF32().length < DEFAULT_WRAP_LENGTH);
 	static assert(str.length > DEFAULT_WRAP_LENGTH);
 	assert(wrapText(unwrapText(str, false, false)).split("\n").length == 1);
+
+	// Rewrap consecutive quoted lines with length greater than DEFAULT_WRAP_LENGTH
+	static assert(wrapText(unwrapText("> Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod \n> tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,", false, false)) ==
+		      "> Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed \n> do eiusmod tempor incididunt ut labore et dolore magna aliqua. \n> Ut enim ad minim veniam,");
 }
+

--- a/wrap.d
+++ b/wrap.d
@@ -20,8 +20,6 @@ module wrap;
 import std.string;
 import std.utf;
 
-import ae.utils.text;
-
 struct Paragraph
 {
 	dstring quotePrefix, text;

--- a/wrap.d
+++ b/wrap.d
@@ -75,7 +75,7 @@ Paragraph[] unwrapText(string text, bool flowed, bool delsp)
 			{
 				buffer = Paragraph(quotePrefix, line ~ " ");
 			}
-			else if (!paragraphs.length > 0) // Always init paragraph
+			else if (!paragraphs.length > 0) // Init paragraph; get next buffer
 			{
 				paragraphs ~= buffer;
 				buffer = Paragraph(quotePrefix, line ~ " ");
@@ -95,7 +95,10 @@ Paragraph[] unwrapText(string text, bool flowed, bool delsp)
 		else if(buffer.text.length > 0// If we have a buffer, but the current line doesn't go over the limit
 			&& (quotePrefix.length + line.length) <= DEFAULT_WRAP_LENGTH)
 		{
-			paragraphs[$-1].text ~= buffer.text;
+			if (!paragraphs.length > 0) // Init paragraph; no new buffer
+				paragraphs ~= buffer;
+			else
+				paragraphs[$-1].text ~= buffer.text;
 			buffer.clear;
 			paragraphs ~= Paragraph(quotePrefix,line); //This short line might be code, or intentionally short
 			paragraphs ~= Paragraph(quotePrefix,""); //This force break is code smell, but I can't figure out how to rm it.


### PR DESCRIPTION
Okay, so it took a month longer than I hoped to come back to this, but Christmas miracles do happen and I think this may be sufficient to make merry for the people in issue #23.

I'm not amazingly happy with how it ended up working, but from what I can tell, the unwrapText() function is the only decent place to do it because all of the original context is present.

The unittest should work, only I can't get any of them to run (runtime failures; didn't chase too hard on that, so I won't be surprised in the slightest if it's my fault).  I think I meant to add more, but I can't for the life of me remember what they were right now.  I just want to at least get this out so I can stop being one of those bums who writes a lot but never puts up code.