### PR TITLE
Fix fts4 table creation

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -127,19 +127,19 @@ CREATE INDEX [SubscriptionPostID] ON [SubscriptionPosts] ([SubscriptionID], [Tim
 CREATE VIRTUAL TABLE [PostSearch] USING fts4([Time], [ThreadMD5], [Group], [Author], [AuthorEmail], [Subject], [Content], [NewThread], order=desc);
 
 -- Table `PostSearch_content`
-CREATE TABLE 'PostSearch_content'(docid INTEGER PRIMARY KEY, 'c0Time', 'c1ThreadMD5', 'c2Group', 'c3Author', 'c4AuthorEmail', 'c5Subject', 'c6Content', 'c7NewThread');
+CREATE TABLE IF NOT EXISTS 'PostSearch_content'(docid INTEGER PRIMARY KEY, 'c0Time', 'c1ThreadMD5', 'c2Group', 'c3Author', 'c4AuthorEmail', 'c5Subject', 'c6Content', 'c7NewThread');
 
 -- Table `PostSearch_segments`
-CREATE TABLE 'PostSearch_segments'(blockid INTEGER PRIMARY KEY, block BLOB);
+CREATE TABLE IF NOT EXISTS 'PostSearch_segments'(blockid INTEGER PRIMARY KEY, block BLOB);
 
 -- Table `PostSearch_segdir`
-CREATE TABLE 'PostSearch_segdir'(level INTEGER,idx INTEGER,start_block INTEGER,leaves_end_block INTEGER,end_block INTEGER,root BLOB,PRIMARY KEY(level, idx));
+CREATE TABLE IF NOT EXISTS 'PostSearch_segdir'(level INTEGER,idx INTEGER,start_block INTEGER,leaves_end_block INTEGER,end_block INTEGER,root BLOB,PRIMARY KEY(level, idx));
 
 -- Table `PostSearch_docsize`
-CREATE TABLE 'PostSearch_docsize'(docid INTEGER PRIMARY KEY, size BLOB);
+CREATE TABLE IF NOT EXISTS 'PostSearch_docsize'(docid INTEGER PRIMARY KEY, size BLOB);
 
 -- Table `PostSearch_stat`
-CREATE TABLE 'PostSearch_stat'(id INTEGER PRIMARY KEY, value BLOB);
+CREATE TABLE IF NOT EXISTS 'PostSearch_stat'(id INTEGER PRIMARY KEY, value BLOB);
 
 -- Index `ThreadCreated` on table `Threads`
 CREATE INDEX [ThreadCreated] ON [Threads] ([Created] DESC);


### PR DESCRIPTION
On a recent version of sqlite3, FTS4 sub-tables are automatically
created, resulting in failure when attempting to re-create them.

Only create the sub-tables if they have not been automatically
created.

---

The previous error was:

```
Creating new database from schema
Error: near line 130: table 'PostSearch_content' already exists
Error: near line 133: table 'PostSearch_segments' already exists
Error: near line 136: table 'PostSearch_segdir' already exists
Error: near line 139: table 'PostSearch_docsize' already exists
Error: near line 142: table 'PostSearch_stat' already exists
object.Exception@database.d(122): sqlite3 failed
```