### PR TITLE
remove #content's padding-bottom when footer is not shown

### DIFF
--- a/web/static/css/dfeed.css
+++ b/web/static/css/dfeed.css
@@ -1175,6 +1175,9 @@ body {
 	div#footernav, div#copyright {
 		display: none;
 	}
+	#content {
+		padding-bottom: 0;
+	}
 
 	.horizontal-post-info {
 		display: none;


### PR DESCRIPTION
> Sigh, there is still some wasted space at the bottom on small screens...

Before/after:

![diff-a-after1](https://cloud.githubusercontent.com/assets/9287500/14228269/6768bb06-f910-11e5-862e-905914c686d3.png)
