### PR TITLE
Remembering how many captchas passed, limiting the number asked for

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -55,7 +55,13 @@ CREATE INDEX "ThreadID" ON "Threads" ( ID );
 CREATE INDEX PostParentID ON Posts ( ParentID );
 
 -- Table `Users`
-CREATE TABLE [Users] ( [Username] VARCHAR(50), [Password] VARCHAR(50), [Session] VARCHAR(50) , [Level] INTEGER NOT NULL DEFAULT 0);
+CREATE TABLE [Users] ( 
+[Username] VARCHAR(50), 
+[Password] VARCHAR(50), 
+[Session] VARCHAR(50) , 
+[Level] INTEGER NOT NULL DEFAULT 0,
+[spamchecks] INTEGER NOT NULL DEFAULT 0,
+[captchas] INTEGER NOT NULL DEFAULT 0);
 
 -- Index `UserName` on table `Users`
 CREATE UNIQUE INDEX [UserName] ON [Users] ( [Username] );

--- a/user.d
+++ b/user.d
@@ -276,7 +276,7 @@ class GuestUser : User
 	{
 		enforce(username.length, "Please enter a username");
 		enforce(username.length < 32, "Username too long");
-		enforce(password.length < 64, "Password too long");
+		enforce(password.length < 0x1000, "Password too long");
 
 		// Create user
 		auto session = randomString();


### PR DESCRIPTION
This is sort of what I was thinking. Some users (like myself) get an endless stream of demands from Akismet no matter what we do, and it really would make the site more performant if it didn't query that place for every post, even those of well established users. So, this commit checks how many captchas a user has filled out, and if that number is high enough, does not check their account for spam anymore. The number could be set arbitrarily high, however much before spammers give up trying, but eventually users should silently start seeing their posts just succeed, even if they would have been a false positive on Akismet.

This compiles, but I have no real way to test whether it actually works or not. With or without my commit, running dfeed just gives me the reply "Internal Server Error" for every URL with no diagnostic information anywhere.

Anyway, I just wanted to put out there what sort of change I wanted to see in the forum.