### PR TITLE
New thread guidelines

### DIFF
--- a/config/web.ini.sample
+++ b/config/web.ini.sample
@@ -15,4 +15,4 @@
 # addr = 127.0.0.1
 
 # Port to listen on.
-port = 80
+port = 8080

--- a/groups.d
+++ b/groups.d
@@ -35,7 +35,8 @@ struct Config
 
 	struct Group
 	{
-		string internalName, publicName, urlName, groupSet, description, postMessage, sinkType, sinkName;
+		string internalName, publicName, urlName, groupSet, description,
+		       postMessage, sinkType, sinkName, newThreadGuidelines;
 		string[] urlAliases;
 		OrderedMap!(string, AlsoVia) alsoVia;
 	}

--- a/web.d
+++ b/web.d
@@ -4005,7 +4005,7 @@ class NotFoundException : Exception
 struct ListenConfig
 {
 	string addr;
-	ushort port = 80;
+	ushort port = 8000;
 }
 
 struct Config

--- a/web.d
+++ b/web.d
@@ -2484,15 +2484,18 @@ bool discussionPostForm(PostDraft draft, bool showCaptcha=false, PostError error
 
 	html.put(
 		`<div id="postform-info">`
-			`Posting to <b>`), html.putEncodedEntities(info.publicName), html.put(`</b>`,
-			(parent
-				? parentInfo
+			`Posting to <b>`), html.putEncodedEntities(info.publicName),
+	html.put(`</b>`,(parent ? parentInfo
 					? ` in reply to ` ~ postLink(parentInfo)
 					: ` in reply to (unknown post)`
 				: info
 					? `:<br>(<b>` ~ encodeHtmlEntities(info.description) ~ `</b>)`
-					: ``),
-		`</div>`
+			        : ``));
+    if (info.newThreadGuidelines)
+		html.put(`<br>`
+		         `Please review the <a href="`, info.newThreadGuidelines,`" > guidelines on creating a new thread in `, info.publicName, `</a>`);
+
+	html.put(`</div>`
 		`<input type="hidden" name="secret" value="`, userSettings.secret, `">`
 		`<input type="hidden" name="did" value="`), html.putEncodedEntities(draftID), html.put(`">`
 		`<label for="postform-name">Your name:</label>`


### PR DESCRIPTION
Fixes #69 by allowing to set a custom url for a thread that display the guidelines for this thread.
I thought supplying a URL is more flexible than hard-coding HTML and it's inspired after Github contribution guidelines:

https://github.com/blog/1184-contributing-guidelines

I think if it's an URL not all people won't bother reading anyway, so it's a less intrusive addition than putting some guidelines directly on the page. However also not as effective ;-)

Btw I had some troubles running DFeed, because for non-sudo user it isn't allowed to use ports lower than 1024. Hence as an improvement for other newcomers, the first commit sets the default port to 8080