### PR TITLE
Add ability to expand/collapse posts summary

### DIFF
--- a/web.d
+++ b/web.d
@@ -1104,6 +1104,11 @@ string[] tips =
 	`If you encounter a bug or need a missing feature, you can <a href="https://github.com/CyberShadow/DFeed/issues">create an issue on GitHub</a>.`,
 ];
 
+void expandCollpseButton()
+{
+    html.put(`<div align="left"><a href="#" id="posts-settings" class="posts-settings-collapsed">expand posts [+]</a></div>`);
+}
+
 int[string] getThreadCounts()
 {
 	enum PERF_SCOPE = "getThreadCounts"; mixin(MeasurePerformanceMixin);
@@ -1139,6 +1144,7 @@ Cached!(string[string]) lastPostCache;
 void discussionIndex()
 {
 	discussionIndexHeader();
+	expandCollpseButton();
 
 	auto threadCounts = threadCountCache(getThreadCounts());
 	auto postCounts = postCountCache(getPostCounts());
@@ -1462,6 +1468,7 @@ void discussionGroup(GroupInfo groupInfo, int page)
 				`<br>(<a href="`, idToUrl(thread.id, "first-unread"), `">`, formatNumber(thread.unreadPostCount), ` new</a>)`);
 	}
 
+	expandCollpseButton();
 	html.put(
 		`<table id="group-index" class="forum-table">` ~
 		`<tr class="table-fixed-dummy">`, `<td></td>`.replicate(3), `</tr>` ~ // Fixed layout dummies
@@ -1685,6 +1692,7 @@ void discussionGroupThreaded(GroupInfo groupInfo, int page, bool narrow = false)
 
 void discussionGroupSplit(GroupInfo groupInfo, int page)
 {
+	expandCollpseButton();
 	html.put(
 		`<table id="group-split"><tr>` ~
 		`<td id="group-split-list"><div>`);

--- a/web.d
+++ b/web.d
@@ -1172,7 +1172,7 @@ void discussionIndex()
 		foreach (group; set.groups)
 		{
 			html.put(
-				`<tr class="group-row">` ~
+				`<tr class="group-row post-collapsed" id="`, group.urlName,`-row">` ~
 					`<td class="forum-index-col-forum">` ~
 						`<a href="/group/`), html.putEncodedEntities(group.urlName), html.put(`">`), html.putEncodedEntities(group.publicName), html.put(`</a>` ~
 						`<div class="truncated forum-index-description" title="`), html.putEncodedEntities(group.description), html.put(`">`), html.putEncodedEntities(group.description), html.put(`</div>` ~
@@ -1469,7 +1469,7 @@ void discussionGroup(GroupInfo groupInfo, int page)
 		`<tr class="subheader"><th>Thread / Thread Starter</th><th>Last Post</th><th>Replies</th>`);
 	foreach (thread; threads)
 		html.put(
-			`<tr class="thread-row">` ~
+			`<tr class="thread-row post-collapsed" id="`, thread.id,`">` ~
 				`<td class="group-index-col-first">`), summarizeThread(thread.id, thread.firstPost, thread.isRead), html.put(`</td>` ~
 				`<td class="group-index-col-last">`), summarizeLastPost(thread.lastPost), html.put(`</td>` ~
 				`<td class="number-column">`), summarizePostCount(thread), html.put(`</td>` ~
@@ -1625,7 +1625,7 @@ void formatThreadedPosts(PostInfo*[] postInfos, bool narrow, string selectedID =
 			if (post.ghost)
 				return formatPosts(post.children, level, post.subject, false);
 			html.put(
-				`<tr class="thread-post-row`, (post.info && post.info.id==selectedID ? ` focused selected` : ``), `">` ~
+				`<tr class="thread-post-row`, (post.info && post.info.id==selectedID ? ` focused selected` : ``), ` post-collapsed" id="`, to!string(post.info.rowid), `">` ~
 					`<td>` ~
 						`<div style="padding-left: `, format("%1.1f", OFFSET_INIT + level * offsetIncrement), OFFSET_UNITS, `">` ~
 							`<div class="thread-post-time">`, summarizeTime(post.info.time, true), `</div>`,

--- a/web/static/js/dfeed.js
+++ b/web/static/js/dfeed.js
@@ -34,6 +34,27 @@ $(document).ready(function() {
 	$('.post-expanded').click(function(event) {
 		return expandPost(event, $(this).attr('id'));
 	});
+
+	$('#posts-settings').click(function(event) {
+		let elm = $(event.target);
+		if (elm.hasClass('posts-settings-collapsed')) {
+			$('.post-collapsed').each(function(i, post) {
+				$(post).trigger( "click" );
+			});
+			elm.text('collapse posts [-]')
+				.removeClass('posts-settings-collapsed')
+				.addClass('posts-settings-expanded');
+		}
+		else {
+			$('.post-expanded').each(function(i, post) {
+				$(post).trigger( "click" );
+			});
+			elm.text('expand posts [+]')
+				.removeClass('posts-settings-expanded')
+				.addClass('posts-settings-collapsed');
+		}
+		return false;
+	});
 });
 
 // **************************************************************************

--- a/web/static/js/dfeed.js
+++ b/web/static/js/dfeed.js
@@ -26,6 +26,14 @@ $(document).ready(function() {
 	    container.toggleClass('open');
 	    return false;
 	});
+
+	$('.post-collapsed').click(function(event) {
+		return expandPost(event, $(this).attr('id'));
+	});
+
+	$('.post-expanded').click(function(event) {
+		return expandPost(event, $(this).attr('id'));
+	});
 });
 
 // **************************************************************************
@@ -55,6 +63,46 @@ function initThreadUrlFixer() {
 			return true;
 		});
 	}
+}
+
+// **************************************************************************
+// Toggle a forum summary post in a thread between expanded and collapsed
+
+function expandPost(event, elm_id) {
+	// Don't expand if it was a redirect link. A redirect can happen if the
+	// event fired or any of its parents contains an href.
+	// Threaded views don't redirect but they have 'postlink' as a class.
+	let elm = event.target;
+	let postlink_found = false;
+	while (elm.id != elm_id) {
+		if (elm.href) {
+			return true;
+		}
+		if ($(elm).hasClass("postlink")) {
+			postlink_found = true;
+		}
+		elm = elm.parentNode;
+	}
+
+	let expand = "not-set-yet";
+	function recurseChildren(elm) {
+		if ($(elm).hasClass("truncated")) {
+			$(elm).css("whiteSpace", expand ? "normal" : "nowrap");
+		}
+		$.map(elm.childNodes, recurseChildren);
+	}
+	const collapsed_name = "post-collapsed";
+	const expanded_name = "post-expanded";
+	if ($(elm).hasClass(collapsed_name)) {
+		$(elm).removeClass(collapsed_name).addClass(expanded_name);
+		expand = true;
+	}
+	else {
+		$(elm).removeClass(expanded_name).addClass(collapsed_name);
+		expand = false;
+	}
+	recurseChildren(elm);
+	return postlink_found ? true : false;
 }
 
 // **************************************************************************


### PR DESCRIPTION
The first commit adds the ability to expand a long post summary by clicking on an empty space in the post and collapses it on clicking on an empty space again.
The second commit adds a small link at the top of the page that expands or collapses all the posts in the page.

My javascript and jquery knowledge are limited, so apologies if some stuff aren't done in an idiomatic way.