### PR TITLE
Improve Gravatar alt text, fix request fail design

### DIFF
--- a/src/dfeed/web/web/part/gravatar.d
+++ b/src/dfeed/web/web/part/gravatar.d
@@ -40,11 +40,18 @@ string getGravatarHash(string email)
 	return email.toLower().strip().md5Of().toHexString!(LetterCase.lower)().idup; // Issue 9279
 }
 
-void putGravatar(string gravatarHash, string linkTarget, string aProps = null, int size = 0)
+void putGravatar(string gravatarHash, string personName, string linkTarget, string linkDescription, string aProps = null, int size = 0)
 {
 	html.put(
 		`<a `, aProps, ` href="`), html.putEncodedEntities(linkTarget), html.put(`">` ~
-			`<img alt="Gravatar" class="post-gravatar" `);
+			`<img class="post-gravatar" alt="Gravatar of `), html.putEncodedEntities(personName),
+			html.put(`" `);
+	if (linkDescription.length)
+	{
+		html.put(`title="`), html.putEncodedEntities(linkDescription),
+		html.put(`" aria-label="`), html.putEncodedEntities(linkDescription),
+		html.put(`" `);
+	}
 	if (size)
 	{
 		string sizeStr = size ? text(size) : null;

--- a/src/dfeed/web/web/part/post.d
+++ b/src/dfeed/web/web/part/post.d
@@ -142,7 +142,7 @@ void miniPostInfo(Rfc850Post post, Rfc850Post[string] knownPosts, bool showActio
 		html.put(
 			`<table class="mini-post-info"><tr>` ~
 				`<td class="mini-post-info-avatar">`);
-		putGravatar(gravatarHash, "http://www.gravatar.com/" ~ gravatarHash, `title="` ~ encodeHtmlEntities(_!`%s's Gravatar profile`.format(author)) ~ `"`, 32);
+		putGravatar(gravatarHash, author, "http://www.gravatar.com/" ~ gravatarHash, _!`%s's Gravatar profile`.format(author), null, 32);
 		html.put(
 				`</td>` ~
 				`<td>` ~
@@ -237,7 +237,7 @@ void formatPost(Rfc850Post post, Rfc850Post[string] knownPosts, bool markAsRead 
 			`<tr>` ~
 				`<td class="post-info">` ~
 					`<div class="post-author">`), html.putEncodedEntities(author), html.put(`</div>`);
-		putGravatar(gravatarHash, "http://www.gravatar.com/" ~ gravatarHash, `title="` ~ encodeHtmlEntities(_!`%s's Gravatar profile"`.format(author)), 80);
+		putGravatar(gravatarHash, author, "http://www.gravatar.com/" ~ gravatarHash, _!`%s's Gravatar profile`.format(author), null, 80);
 		if (infoBits.length)
 		{
 			html.put(`<hr>`);

--- a/src/dfeed/web/web/view/group.d
+++ b/src/dfeed/web/web/view/group.d
@@ -113,7 +113,7 @@ void discussionGroup(GroupInfo groupInfo, int page)
 		if (info)
 			with (*info)
 			{
-				putGravatar(getGravatarHash(info.authorEmail), idToUrl(tid, "thread"), `class="forum-postsummary-gravatar" `);
+				putGravatar(getGravatarHash(info.authorEmail), author, idToUrl(tid, "thread"), null, `class="forum-postsummary-gravatar" `);
 				html.put(
 				//	`<!-- Thread ID: ` ~ encodeHtmlEntities(threadID) ~ ` | First Post ID: ` ~ encodeHtmlEntities(id) ~ `-->` ~
 					`<div class="truncated"><a class="forum-postsummary-subject `, (isRead ? "forum-read" : "forum-unread"), `" href="`), html.putEncodedEntities(idToUrl(tid, "thread")), html.put(`" title="`), html.putEncodedEntities(subject), html.put(`">`), html.putEncodedEntities(subject), html.put(`</a></div>` ~

--- a/src/dfeed/web/web/view/post.d
+++ b/src/dfeed/web/web/view/post.d
@@ -102,7 +102,7 @@ void formatSplitPost(Rfc850Post post, bool footerNav)
 			`<tr><td class="horizontal-post-info">` ~
 				`<table><tr>` ~
 					`<td class="post-info-avatar" rowspan="`, text(infoRows.length), `">`);
-		putGravatar(gravatarHash, "http://www.gravatar.com/" ~ gravatarHash, `title="` ~ _!`%s's Gravatar profile`.format(encodeHtmlEntities(author)) ~ `"`, 48);
+		putGravatar(gravatarHash, author, "http://www.gravatar.com/" ~ gravatarHash, _!`%s's Gravatar profile`.format(author), null, 48);
 		html.put(
 					`</td>` ~
 					`<td><table>`);

--- a/src/dfeed/web/web/view/search.d
+++ b/src/dfeed/web/web/view/search.d
@@ -291,7 +291,7 @@ void formatSearchResult(Rfc850Post post, string snippet)
 			`<tr>` ~
 				`<td class="post-info">` ~
 					`<div class="post-author">`), html.putEncodedEntities(author), html.put(`</div>`);
-		putGravatar(gravatarHash, "http://www.gravatar.com/" ~ gravatarHash, `title="` ~ _!`%s's Gravatar profile`.format(encodeHtmlEntities(author)) ~ `"`, 80);
+		putGravatar(gravatarHash, author, "http://www.gravatar.com/" ~ gravatarHash, _!`%s's Gravatar profile`.format(author), null, 80);
 
 		html.put(
 				`</td>` ~

--- a/src/dfeed/web/web/view/widgets.d
+++ b/src/dfeed/web/web/view/widgets.d
@@ -79,7 +79,7 @@ void summarizeFrameThread(PostInfo* info, string infoText)
 	if (info)
 		with (*info)
 		{
-			putGravatar(getGravatarHash(info.authorEmail), idToUrl(id), `target="_top" class="forum-postsummary-gravatar" `);
+			putGravatar(getGravatarHash(info.authorEmail), author, idToUrl(id), null, `target="_top" class="forum-postsummary-gravatar" `);
 			html.put(
 				`<a target="_top" class="forum-postsummary-subject `, (user.isRead(rowid) ? "forum-read" : "forum-unread"), `" href="`), html.putEncodedEntities(idToUrl(id)), html.put(`">`), html.putEncodedEntities(subject), html.put(`</a><br>` ~
 				`<div class="forum-postsummary-info">`, infoText, `</div>`,

--- a/web/static/css/dfeed.css
+++ b/web/static/css/dfeed.css
@@ -395,10 +395,13 @@ div#footernav a {
 }
 
 #group-index a.forum-postsummary-gravatar img.post-gravatar {
-	width : 2.2em;
-	height: 2.2em;
-	border-width: 0.3em;
+	width : 2.2rem;
+	height: 2.2rem;
+	border-width: 0.3rem;
 	margin: 0;
+	overflow: hidden;
+	font-size: 6pt;
+	text-align: center;
 }
 
 /*************** Thread view, individual posts ***************/


### PR DESCRIPTION
I have made this an API breaking change because I assume no other project is using that Gravatar function, so I replaced all the occurrences and to make the code more readable + prevent users from passing in empty alt texts, which is bad for accessibility.

Before:
![broken img alt text](https://wfr.moe/f61lVo.png)

After:
![Improved and fixed img alt texts](https://wfr.moe/f61lOW.png)