### PR TITLE
fix OpenSSL >=1.1.0 API usage

### DIFF
--- a/dub.selections.json
+++ b/dub.selections.json
@@ -3,6 +3,6 @@
 	"versions": {
 		"ae": "0.0.3101",
 		"dcaptcha": "1.0.1",
-		"openssl": "1.1.6+1.0.1g"
+		"openssl": "3.3.0"
 	}
 }


### PR DESCRIPTION
Since older OpenSSL versions have been EOLd everywhere unless on CentOS 7, I think we can soon drop the compatibility code as well.